### PR TITLE
Reimplement `probe` / `probe_all` with revertible database

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ serde_derive = "1.0"
 
 [replace."exonum:0.3.0"]
 git = "https://github.com/slowli/exonum"
-rev = "0f356ce6b7036eddb1e6bc85cc871145a42776c2"
+rev = "5de091709e71968e934d649bc986725d7cecd1a8"

--- a/src/checkpoint_db.rs
+++ b/src/checkpoint_db.rs
@@ -1,0 +1,303 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use exonum::storage::{Database, Patch, Change, Result as StorageResult, Snapshot};
+
+/// Implementation of a `Database`, which allows to rollback commits introduced by the `merge()`
+/// function.
+///
+/// **Note:** Intended for testing purposes only. Probably inefficient.
+#[derive(Clone, Debug)]
+pub struct CheckpointDb<T> {
+    inner: T,
+    journal: Arc<RwLock<Vec<Patch>>>,
+}
+
+impl<T: Database + Clone> CheckpointDb<T> {
+    /// Creates a new checkpointed database that uses the specified `db` as the underlying
+    /// data storage.
+    pub fn new(db: T) -> Self {
+        CheckpointDb {
+            inner: db,
+            journal: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Rolls this database by udoing the latest `count` `merge()` operations.
+    pub fn rollback(&mut self, count: usize) -> bool {
+        let journal_len = self.journal
+            .read()
+            .expect("Cannot acquire read lock on journal")
+            .len();
+        assert!(
+            journal_len >= count,
+            "Cannot rollback {} changes; only {} checkpoints in the journal",
+            count,
+            journal_len
+        );
+
+        let mut journal = self.journal.write().expect(
+            "Cannot acquire write lock on journal",
+        );
+
+        for _ in 0..count {
+            if let Some(patch) = journal.pop() {
+                self.inner.merge(patch).expect(
+                    "Cannot merge roll-back patch",
+                );
+            } else {
+                panic!("Cannot rollback the database, the journal is empty");
+            }
+        }
+
+        journal_len < count
+    }
+
+    /// Returns a handler to the database. The handler could be used to roll the database back
+    /// without having the ownership to it.
+    pub fn handler(&self) -> CheckpointDbHandler<T> {
+        CheckpointDbHandler(Clone::clone(self))
+    }
+}
+
+impl<T: Database + Clone> Database for CheckpointDb<T> {
+    fn clone(&self) -> Box<Database> {
+        Box::new(Clone::clone(self))
+    }
+
+    fn snapshot(&self) -> Box<Snapshot> {
+        self.inner.snapshot()
+    }
+
+    fn merge(&mut self, patch: Patch) -> StorageResult<()> {
+        let snapshot = self.inner.snapshot();
+        let mut rev_patch = Patch::new();
+
+        for (name, kv_map) in &patch {
+            let mut rev_kv_map = BTreeMap::new();
+            for key in kv_map.keys() {
+                match snapshot.get(name, key) {
+                    Some(value) => {
+                        rev_kv_map.insert(key.clone(), Change::Put(value));
+                    }
+                    None => {
+                        rev_kv_map.insert(key.clone(), Change::Delete);
+                    }
+                }
+            }
+            rev_patch.insert(name.to_string(), rev_kv_map);
+        }
+
+        {
+            let mut journal = self.journal.write().expect(
+                "Cannot acquire write lock on journal",
+            );
+            journal.push(rev_patch);
+        }
+        self.inner.merge(patch)
+    }
+}
+
+/// Handler to a checkpointed database.
+#[derive(Clone, Debug)]
+pub struct CheckpointDbHandler<T>(CheckpointDb<T>);
+
+impl<T: Database + Clone> CheckpointDbHandler<T> {
+    /// Rolls this database by udoing the latest `count` `merge()` operations.
+    pub fn rollback(&mut self, count: usize) -> bool {
+        self.0.rollback(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use exonum::storage::MemoryDB;
+    use super::*;
+
+    fn create_patch<'a, I>(from: I) -> Patch
+    where
+        I: IntoIterator<Item = (&'a str, Vec<u8>, Change)>,
+    {
+        let mut patch = Patch::new();
+
+        for (name, key, value) in from.into_iter() {
+            let name = name.to_string();
+            let kv_map = patch.entry(name).or_insert_with(BTreeMap::new);
+            if kv_map.insert(key, value).is_some() {
+                panic!("Attempt to re-insert a key into patch");
+            }
+        }
+
+        patch
+    }
+
+    #[test]
+    fn test_checkpointdb_basics() {
+        let mut db = CheckpointDb::new(MemoryDB::new());
+        let mut fork = db.fork();
+        fork.put("foo", vec![], vec![2]);
+        db.merge(fork.into_patch()).unwrap();
+        {
+            let journal = db.journal.read().expect(
+                "Cannot acquire read lock on journal",
+            );
+            assert_eq!(journal.len(), 1);
+            assert_eq!(
+                journal[0],
+                create_patch(vec![("foo", vec![], Change::Delete)])
+            );
+        }
+
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
+
+        let mut fork = db.fork();
+        fork.put("foo", vec![], vec![3]);
+        fork.put("bar", vec![1], vec![4]);
+        db.merge(fork.into_patch()).unwrap();
+        {
+            let journal = db.journal.read().expect(
+                "Cannot acquire read lock on journal",
+            );
+            assert_eq!(journal.len(), 2);
+            assert_eq!(
+                journal[0],
+                create_patch(vec![("foo", vec![], Change::Delete)])
+            );
+            assert_eq!(
+                journal[1],
+                create_patch(vec![
+                    ("foo", vec![], Change::Put(vec![2])),
+                    ("bar", vec![1], Change::Delete),
+                ])
+            );
+        }
+
+        // Check that the old snapshot still corresponds to the same DB state
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![3]));
+    }
+
+    #[test]
+    fn test_checkpointdb_rollback() {
+        let mut db = CheckpointDb::new(MemoryDB::new());
+        let mut fork = db.fork();
+        fork.put("foo", vec![], vec![2]);
+        db.merge(fork.into_patch()).unwrap();
+
+        let mut fork = db.fork();
+        fork.put("foo", vec![], vec![3]);
+        fork.put("bar", vec![1], vec![4]);
+        db.merge(fork.into_patch()).unwrap();
+        {
+            let journal = db.journal.read().expect(
+                "Cannot acquire read lock on journal",
+            );
+            assert_eq!(journal.len(), 2);
+        }
+
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![3]));
+        db.rollback(1);
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
+        assert_eq!(snapshot.get("bar", &[1]), None);
+        {
+            let journal = db.journal.read().expect(
+                "Cannot acquire read lock on journal",
+            );
+            assert_eq!(journal.len(), 1);
+        }
+
+        // Check that DB continues working as usual after a rollback
+        let mut fork = db.fork();
+        fork.put("foo", vec![], vec![4]);
+        fork.put("foo", vec![0, 0], vec![255]);
+        db.merge(fork.into_patch()).unwrap();
+        {
+            let journal = db.journal.read().expect(
+                "Cannot acquire read lock on journal",
+            );
+            assert_eq!(journal.len(), 2);
+        }
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![4]));
+        assert_eq!(snapshot.get("foo", &[0, 0]), Some(vec![255]));
+
+        let mut fork = db.fork();
+        fork.put("bar", vec![1], vec![254]);
+        db.merge(fork.into_patch()).unwrap();
+        {
+            let journal = db.journal.read().expect(
+                "Cannot acquire read lock on journal",
+            );
+            assert_eq!(journal.len(), 3);
+        }
+        let new_snapshot = db.snapshot();
+        assert_eq!(new_snapshot.get("foo", &[]), Some(vec![4]));
+        assert_eq!(new_snapshot.get("foo", &[0, 0]), Some(vec![255]));
+        assert_eq!(new_snapshot.get("bar", &[1]), Some(vec![254]));
+
+        db.rollback(2);
+        {
+            let journal = db.journal.read().expect(
+                "Cannot acquire read lock on journal",
+            );
+            assert_eq!(journal.len(), 1);
+        }
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
+        assert_eq!(snapshot.get("foo", &[0, 0]), None);
+        assert_eq!(snapshot.get("bar", &[1]), None);
+
+        assert_eq!(new_snapshot.get("foo", &[]), Some(vec![4]));
+        assert_eq!(new_snapshot.get("foo", &[0, 0]), Some(vec![255]));
+        assert_eq!(new_snapshot.get("bar", &[1]), Some(vec![254]));
+    }
+
+    #[test]
+    fn test_checkpointdb_clone() {
+        let mut db = CheckpointDb::new(MemoryDB::new());
+        let mut db_clone = Database::clone(&db);
+
+        let mut fork = db.fork();
+        fork.put("foo", vec![], vec![2]);
+        db.merge(fork.into_patch()).unwrap();
+
+        let snapshot = db_clone.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
+
+        let mut fork = db_clone.fork();
+        fork.put("foo", vec![], vec![3]);
+        db_clone.merge(fork.into_patch()).unwrap();
+
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![3]));
+
+        // Check rollback on clones
+        let mut db_clone = Clone::clone(&db);
+        db_clone.rollback(1);
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
+        db.rollback(1);
+        let snapshot = db_clone.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), None);
+    }
+
+    #[test]
+    fn test_checkpointdb_handler() {
+        let mut db = CheckpointDb::new(MemoryDB::new());
+        let mut db_handler = db.handler();
+
+        let mut fork = db.fork();
+        fork.put("foo", vec![], vec![2]);
+        db.merge(fork.into_patch()).unwrap();
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
+
+        db_handler.rollback(1);
+        let snapshot = db.snapshot();
+        assert_eq!(snapshot.get("foo", &[]), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,26 @@ use checkpoint_db::{CheckpointDb, CheckpointDbHandler};
 
 const STATE_UPDATE_TIMEOUT: u64 = 10_000;
 
+/// Macro allowing to create `Vec<Box<Transaction>>` from transaction references. Can be used for
+/// `TestHarness.probe_all()`, among other things.
+///
+/// As the macro syntax implies, the transactions are not consumed; they are rather cloned before
+/// being put into `Box`es.
+///
+/// # Examples
+///
+/// ```ignore
+/// let tx = TxCreateWallet::new(..);
+/// let other_tx = TxTransfer::new(..);
+/// let txs = txvec![&tx, &other_tx];
+/// ```
+#[macro_export]
+macro_rules! txvec {
+    ($(&$tx:ident),+ $(,)*) => {
+        vec![$(Box::new($tx.clone()) as Box<exonum::blockchain::Transaction>,)+]
+    };
+}
+
 /// Emulated test network.
 pub struct TestNetwork {
     validators: Vec<Validator>,

--- a/tests/test_counter.rs
+++ b/tests/test_counter.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate exonum;
+#[macro_use]
 extern crate exonum_harness;
 extern crate serde;
 #[macro_use]
@@ -364,7 +365,7 @@ fn test_probe() {
         TxIncrement::new(&pubkey, 3, &key)
     };
 
-    let snapshot = harness.probe_all(vec![Box::new(tx.clone()), Box::new(other_tx.clone())]);
+    let snapshot = harness.probe_all(txvec![&tx, &other_tx]);
     let schema = CounterSchema::new(&snapshot);
     assert_eq!(schema.count(), Some(8));
 
@@ -396,13 +397,13 @@ fn test_duplicate_tx() {
 #[test]
 #[should_panic(expected = "Duplicate transactions in probe")]
 fn test_probe_duplicate_tx_panic() {
-    let (harness, _) = init_harness();
+    let (mut harness, _) = init_harness();
 
     let tx = {
         let (pubkey, key) = crypto::gen_keypair();
         TxIncrement::new(&pubkey, 6, &key)
     };
-    let snapshot = harness.probe_all(vec![Box::new(tx.clone()), Box::new(tx.clone())]);
+    let snapshot = harness.probe_all(txvec![&tx, &tx]);
     drop(snapshot);
 }
 
@@ -436,10 +437,10 @@ fn test_probe_advanced() {
     assert_eq!(schema.count(), None);
 
     // Check dependency of the resulting snapshot on tx ordering
-    let snapshot = harness.probe_all(vec![Box::new(tx.clone()), Box::new(admin_tx.clone())]);
+    let snapshot = harness.probe_all(txvec![&tx, &admin_tx]);
     let schema = CounterSchema::new(&snapshot);
     assert_eq!(schema.count(), Some(0));
-    let snapshot = harness.probe_all(vec![Box::new(admin_tx.clone()), Box::new(tx.clone())]);
+    let snapshot = harness.probe_all(txvec![&admin_tx, &tx]);
     let schema = CounterSchema::new(&snapshot);
     assert_eq!(schema.count(), Some(6));
     // Check that data is (still) not persisted
@@ -462,10 +463,10 @@ fn test_probe_advanced() {
     assert_eq!(schema.count(), Some(10));
 
     // Check dependency of the resulting snapshot on tx ordering
-    let snapshot = harness.probe_all(vec![Box::new(tx.clone()), Box::new(admin_tx.clone())]);
+    let snapshot = harness.probe_all(txvec![&tx, &admin_tx]);
     let schema = CounterSchema::new(&snapshot);
     assert_eq!(schema.count(), Some(0));
-    let snapshot = harness.probe_all(vec![Box::new(admin_tx.clone()), Box::new(tx.clone())]);
+    let snapshot = harness.probe_all(txvec![&admin_tx, &tx]);
     let schema = CounterSchema::new(&snapshot);
     assert_eq!(schema.count(), Some(6));
     // Check that data is (still) not persisted
@@ -493,7 +494,7 @@ fn test_probe_duplicate_tx() {
 
     // Check the mixed case, when some probed transactions are committed and some are not
     let other_tx = inc_count(&api, 7);
-    let snapshot = harness.probe_all(vec![Box::new(tx), Box::new(other_tx)]);
+    let snapshot = harness.probe_all(txvec![&tx, &other_tx]);
     let schema = CounterSchema::new(&snapshot);
     assert_eq!(schema.count(), Some(12));
 }


### PR DESCRIPTION
This PR introduces `CheckpointDb` - a `Database` implementation that allows to revert merges. `probe()` and `probe_all()` methods are re-implemented accordingly.

The PR relies on [another change](https://github.com/slowli/exonum/commit/5de091709e71968e934d649bc986725d7cecd1a8) in the Exonum codebase. It's not strictly necessary, but helps in testing.