### PR TITLE
Fix execution of bogus txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added the usage manual. (#9)
 
+### Fixed
+
+- Fixed incorrect behavior of `TestKit::create_block_with_transactions()`,
+  in which it would execute incorrect transactions. (#11)
+
 ## 0.1 - 2017-12-08
 
 The first release of Exonum testkit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -686,30 +686,31 @@ impl TestKit {
     ///
     /// # Panics
     ///
-    /// - Panics if the one of transactions has been already committed to the blockchain.
+    /// - Panics if any of transactions has been already committed to the blockchain.
     pub fn create_block_with_transactions<I>(&mut self, txs: I)
     where
         I: IntoIterator<Item = Box<Transaction>>,
     {
-        let tx_hashes = {
+        let tx_hashes: Vec<_> = {
             let mut mempool = self.mempool.write().expect(
                 "Cannot write transactions to mempool",
             );
 
-            let mut tx_hashes = Vec::new();
             let snapshot = self.snapshot();
             let schema = CoreSchema::new(&snapshot);
-            for tx in txs {
-                let txid = tx.hash();
-                assert!(
-                    !schema.transactions().contains(&txid),
-                    "Transaction is already committed: {:?}",
-                    tx
-                );
-                tx_hashes.push(txid);
-                mempool.insert(txid, tx);
-            }
-            tx_hashes
+            txs.into_iter()
+                .filter(|tx| tx.verify())
+                .map(|tx| {
+                    let txid = tx.hash();
+                    assert!(
+                        !schema.transactions().contains(&txid),
+                        "Transaction is already committed: {:?}",
+                        tx
+                    );
+                    mempool.insert(txid, tx);
+                    txid
+                })
+                .collect()
         };
         self.create_block_with_tx_hashes(&tx_hashes);
     }


### PR DESCRIPTION
This PR fixes incorrect behavior of the `TestKit::create_block_with_transactions()` method. Before the fix, the method executed transactions, for which `Transaction::verify()` returned `false` (e.g., transactions with incorrect digital signature, or transfers to self in the sample cryptocurrency service; see tests added by this PR). 