### PR TITLE
Add create_block_with_transaction method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `rollback()` method for `TestKit` allowing to rollback blocks added to
   the testkit blockchain. (#8)
-  - Added `TestKit::create_block_with_transaction()` method`. (#13)
+  - Added `TestKit::create_block_with_transaction()` method. (#13)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `rollback()` method for `TestKit` allowing to rollback blocks added to
   the testkit blockchain. (#8)
-  - Added `TestKit::create_block_with_transaction()` method. (#13)
+- Added `TestKit::create_block_with_transaction()` method. (#13)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added `TestKit::create_block_with_transaction()` method`. (#13)
+
 ## 0.1.1 - 2017-12-14
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,8 +695,8 @@ impl TestKit {
         }
     }
 
-    /// Creates block with the given transactions.
-    /// Transactions that are in mempool will be ignored.
+    /// Creates a block with the given transactions.
+    /// Transactions that are in the mempool will be ignored.
     ///
     /// # Panics
     ///
@@ -729,28 +729,14 @@ impl TestKit {
         self.create_block_with_tx_hashes(&tx_hashes);
     }
 
-    /// Creates block with the given transaction.
-    /// Transactions that are in mempool will be ignored.
+    /// Creates a block with the given transaction.
+    /// Transactions that are in the mempool will be ignored.
     ///
     /// # Panics
     ///
     /// - Panics if given transaction has been already committed to the blockchain.
     pub fn create_block_with_transaction<T: Transaction>(&mut self, tx: T) {
-        if !tx.verify() {
-            return;
-        }
-
-        let tx_hash = tx.hash();
-
-        assert!(!CoreSchema::new(self.snapshot()).transactions().contains(&tx_hash),
-            "Transaction is already committed: {:?}",
-            tx);
-
-        self.mempool.write().expect(
-            "Cannot write transaction to mempool",
-        ).insert(tx_hash, Box::new(tx));
-
-        self.create_block_with_tx_hashes(&[tx_hash]);
+        self.create_block_with_transactions(txvec![tx]);
     }
 
     /// Creates block with the specified transactions. The transactions must be previously

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@
 //!         .with_validators(4)
 //!         .with_service(TimestampingService)
 //!         .create();
+//!
 //!     // Create few transactions.
 //!     let keypair = gen_keypair();
 //!     let tx1 = TxTimestamp::new(&keypair.0, "Down To Earth", &keypair.1);
@@ -97,16 +98,23 @@
 //!     testkit.create_block_with_transactions(txvec![
 //!         tx1.clone(), tx2.clone(), tx3.clone()
 //!     ]);
+//!
+//!     // Add a single transaction.
+//!     let tx4 = TxTimestamp::new(&keypair.0, "Barking up the wrong tree", &keypair.1);
+//!     testkit.create_block_with_transaction(tx4.clone());
+//!
 //!     // Check results with schema.
 //!     let snapshot = testkit.snapshot();
 //!     let schema = Schema::new(&snapshot);
 //!     assert!(schema.transactions().contains(&tx1.hash()));
 //!     assert!(schema.transactions().contains(&tx2.hash()));
 //!     assert!(schema.transactions().contains(&tx3.hash()));
+//!     assert!(schema.transactions().contains(&tx4.hash()));
+//!
 //!     // Check results with api.
 //!     let api = testkit.api();
 //!     let blocks: Vec<Block> = api.get(ApiKind::Explorer, "v1/blocks?count=10");
-//!     assert_eq!(blocks.len(), 2);
+//!     assert_eq!(blocks.len(), 3);
 //!     api.get::<serde_json::Value>(
 //!         ApiKind::System,
 //!         &format!("v1/transactions/{}", tx1.hash().to_string()),

--- a/tests/test_counter.rs
+++ b/tests/test_counter.rs
@@ -289,12 +289,18 @@ fn inc_count(api: &TestKitApi, by: u64) -> TxIncrement {
 fn test_inc_count_create_block() {
     let (mut testkit, api) = init_testkit();
     let (pubkey, key) = crypto::gen_keypair();
+
     // Create a presigned transaction
     testkit.create_block_with_transactions(txvec![TxIncrement::new(&pubkey, 5, &key)]);
 
     // Check that the user indeed is persisted by the service
     let counter: u64 = api.get(ApiKind::Service("counter"), "count");
     assert_eq!(counter, 5);
+
+    testkit.create_block_with_transaction(TxIncrement::new(&pubkey, 4, &key));
+
+    let counter: u64 = api.get(ApiKind::Service("counter"), "count");
+    assert_eq!(counter, 9);
 }
 
 #[should_panic(expected = "Transaction is already committed")]

--- a/tests/test_counter.rs
+++ b/tests/test_counter.rs
@@ -291,16 +291,19 @@ fn test_inc_count_create_block() {
     let (pubkey, key) = crypto::gen_keypair();
 
     // Create a presigned transaction
-    testkit.create_block_with_transactions(txvec![TxIncrement::new(&pubkey, 5, &key)]);
+    testkit.create_block_with_transaction(TxIncrement::new(&pubkey, 5, &key));
 
     // Check that the user indeed is persisted by the service
     let counter: u64 = api.get(ApiKind::Service("counter"), "count");
     assert_eq!(counter, 5);
 
-    testkit.create_block_with_transaction(TxIncrement::new(&pubkey, 4, &key));
+    testkit.create_block_with_transactions(txvec![
+        TxIncrement::new(&pubkey, 4, &key),
+        TxIncrement::new(&pubkey, 1, &key),
+    ]);
 
     let counter: u64 = api.get(ApiKind::Service("counter"), "count");
-    assert_eq!(counter, 9);
+    assert_eq!(counter, 10);
 }
 
 #[should_panic(expected = "Transaction is already committed")]
@@ -309,9 +312,9 @@ fn test_inc_count_create_block_with_committed_transaction() {
     let (mut testkit, _) = init_testkit();
     let (pubkey, key) = crypto::gen_keypair();
     // Create a presigned transaction
-    testkit.create_block_with_transactions(txvec![TxIncrement::new(&pubkey, 5, &key)]);
+    testkit.create_block_with_transaction(TxIncrement::new(&pubkey, 5, &key));
     // Create another block with the same transaction
-    testkit.create_block_with_transactions(txvec![TxIncrement::new(&pubkey, 5, &key)]);
+    testkit.create_block_with_transaction(TxIncrement::new(&pubkey, 5, &key));
 }
 
 #[test]


### PR DESCRIPTION
Motivation: often a block is created with a single transaction and this method saves  from using `txvec!` macro (and `#[macro_use]` attribute). 