### PR TITLE
Update to latest exonum master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ router = "0.6.0"
 bodyparser = "0.8.0"
 serde_derive = "1.0.0"
 rand = "0.3"
+
+[patch.crates-io]
+exonum = { git = 'https://github.com/exonum/exonum', rev = 'e1cf9839c' }

--- a/examples/timestamping.rs
+++ b/examples/timestamping.rs
@@ -18,10 +18,10 @@ extern crate exonum;
 extern crate exonum_testkit;
 extern crate serde_json;
 
-use exonum::crypto::{gen_keypair, PublicKey};
+use exonum::crypto::{gen_keypair, Hash, PublicKey};
 use exonum::blockchain::{Block, Schema, Service, Transaction};
 use exonum::messages::{Message, RawTransaction};
-use exonum::storage::Fork;
+use exonum::storage::{Fork, Snapshot};
 use exonum::encoding;
 use exonum_testkit::{ApiKind, TestKitBuilder};
 
@@ -58,6 +58,10 @@ impl Transaction for TxTimestamp {
 impl Service for TimestampingService {
     fn service_name(&self) -> &'static str {
         "timestamping"
+    }
+
+    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+        Vec::new()
     }
 
     fn service_id(&self) -> u16 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@
 //! extern crate exonum_testkit;
 //! extern crate serde_json;
 //!
-//! use exonum::crypto::{gen_keypair, PublicKey};
+//! use exonum::crypto::{gen_keypair, Hash, PublicKey};
 //! use exonum::blockchain::{Block, Schema, Service, Transaction};
 //! use exonum::messages::{Message, RawTransaction};
-//! use exonum::storage::Fork;
+//! use exonum::storage::{Snapshot, Fork};
 //! use exonum::encoding;
 //! use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
@@ -63,6 +63,10 @@
 //! impl Service for TimestampingService {
 //!     fn service_name(&self) -> &'static str {
 //!         "timestamping"
+//!     }
+//!
+//!     fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+//!         Vec::new()
 //!     }
 //!
 //!     fn service_id(&self) -> u16 {
@@ -372,6 +376,9 @@ impl From<TestNode> for ValidatorKeys {
 /// #    fn service_name(&self) -> &'static str {
 /// #        "documentation"
 /// #    }
+/// #    fn state_hash(&self, _: &exonum::storage::Snapshot) -> Vec<exonum::crypto::Hash> {
+/// #        Vec::new()
+/// #    }
 /// #    fn service_id(&self) -> u16 {
 /// #        0
 /// #    }
@@ -593,6 +600,9 @@ impl TestKit {
     /// # impl Service for MyService {
     /// #    fn service_name(&self) -> &'static str {
     /// #        "documentation"
+    /// #    }
+    /// #    fn state_hash(&self, _: &exonum::storage::Snapshot) -> Vec<exonum::crypto::Hash> {
+    /// #        Vec::new()
     /// #    }
     /// #    fn service_id(&self) -> u16 {
     /// #        0

--- a/tests/test_counter.rs
+++ b/tests/test_counter.rs
@@ -225,6 +225,10 @@ mod counter {
             "counter"
         }
 
+        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+            Vec::new()
+        }
+
         fn service_id(&self) -> u16 {
             SERVICE_ID
         }

--- a/tests/test_currency.rs
+++ b/tests/test_currency.rs
@@ -321,6 +321,10 @@ mod cryptocurrency {
             "cryptocurrency"
         }
 
+        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+            Vec::new()
+        }
+
         fn service_id(&self) -> u16 {
             SERVICE_ID
         }

--- a/tests/test_inflating_currency.rs
+++ b/tests/test_inflating_currency.rs
@@ -316,6 +316,10 @@ mod inflating_cryptocurrency {
             "cryptocurrency"
         }
 
+        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+            Vec::new()
+        }
+
         fn service_id(&self) -> u16 {
             SERVICE_ID
         }

--- a/tests/test_service_hooks.rs
+++ b/tests/test_service_hooks.rs
@@ -30,8 +30,8 @@ mod hooks {
 
     use exonum::blockchain::{Service, ServiceContext, Transaction};
     use exonum::messages::RawTransaction;
-    use exonum::storage::Fork;
-    use exonum::crypto::Signature;
+    use exonum::storage::{Fork, Snapshot};
+    use exonum::crypto::{Hash, Signature};
     use exonum::encoding;
     use exonum::helpers::Height;
 
@@ -65,6 +65,10 @@ mod hooks {
     impl Service for HandleCommitService {
         fn service_name(&self) -> &'static str {
             "handle_commit"
+        }
+
+        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+            Vec::new()
         }
 
         fn service_id(&self) -> u16 {


### PR DESCRIPTION
Introduces a lot of placeholder `state_hash` methods (see https://github.com/exonum/exonum/pull/399)