### PR TITLE
Add logging into post and get requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `rollback()` method for `TestKit` allowing to rollback blocks added to
   the testkit blockchain. (#8)
 - Added `TestKit::create_block_with_transaction()` method. (#13)
+- Added basic logging support for requests and responses. (#27)
 
 ### Changed
 
 - Reimplemented `probe()` / `probe_all()` methods of the testkit with
   a revertible database. (#8)
 - Renamed `public_mount` and `private_mount` to `public_handler` and `private_handler`,
-  respectively, and made these methods return `iron::Chain` references. (#23)  
+  respectively, and made these methods return `iron::Chain` references. (#23)
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ travis-ci = { repository = "exonum/exonum-testkit" }
 [dependencies]
 exonum = "0.4.0"
 futures = "0.1.14"
+log = "0.4"
 serde = "1.0.0"
 serde_json = "1.0.0"
 iron = "0.6.0"

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -122,6 +122,13 @@ fn my_api_test() {
 }
 ```
 
+In some situations, it can be useful to see the content of requests and corresponding responses. 
+`exonum-testkit` provides simple logging implementation for this purpose. 
+You can use `RUST_LOG` environment variable to enable logs:
+```
+RUST_LOG=exonum_testkit=trace cargo test
+```
+
 ## Advanced usage
 
 Here are examples of more complex and less common cases.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -122,13 +122,6 @@ fn my_api_test() {
 }
 ```
 
-In some situations, it can be useful to see the content of requests and corresponding responses. 
-`exonum-testkit` provides simple logging implementation for this purpose. 
-You can use `RUST_LOG` environment variable to enable logs:
-```
-RUST_LOG=exonum_testkit=trace cargo test
-```
-
 ## Advanced usage
 
 Here are examples of more complex and less common cases.


### PR DESCRIPTION
This change allows to debug POST/GET requests via `TestKitApi`. At the moment this functionality requires manual changes in specific projects' tests, which is kinda unfortunate.

Usage:
```
cd my-awesome-project-using-testkit
RUST_LOG=exonum_testkit=debug cargo test
```

Example output:
```
[1516698198 : 741] - [ DEBUG ] - exonum_testkit - GET request: http://localhost:3000/api/services/closed_service//v1/some/secret?count=1&from=1 Response: HTTP/1.1 200 OK
Content-Length: 132
Content-Type: application/json
```
```
[1516698198 : 743] - [ DEBUG ] - exonum_testkit - POST request: http://localhost:3000/api/services/secret_service//v1/secrets Body: {"body":{"content":{"content_hash":"0000000000000000000000000000000000000000000000000000000000000000","metadata":"metadata","user_id":"User"},"pub_key":"f4e5d9ecb97d7687080e17007758721c7941758ad7f292d1fd6f1c37bb91c5b1"},"message_id":2,"network_id":0,"protocol_version":0,"service_id":128,"signature":"cfd2d757ea39fddab369418fe73c364a858abc29790678b5c2a550efdc4e37225eec5c7b6eaba1ffb1a78e2ad7c4a0fac3ad2aa6f76016740756fafc216a2c09"} Response: "0a5194ac456bc4fadb83712d948ae67f0473ac34a469a5f1a7fc3f56e4bf131f"
```